### PR TITLE
refactoring controller logging | separating it in its own class

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,33 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 
-import * as winston from 'winston';
-import { WinstonModule } from 'nest-winston';
-
 import { WatchesModule } from './watches/watches.module';
 
 @Module({
   imports: [
-    WinstonModule.forRoot({
-      level: 'error',
-      format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.prettyPrint()
-      ),
-      defaultMeta: { service: 'rest-api' },
-      transports: [
-        new winston.transports.File({
-          dirname: 'logs',
-          filename: 'error.log',
-          level: 'error'
-        }),
-        new winston.transports.File({
-          dirname: 'logs',
-          filename: 'combined.log',
-          level: 'http'
-        })
-      ]
-    }),
     TypeOrmModule.forRoot({
       type: 'postgres',
       connectTimeoutMS: process.env.PG_CONNECTION_TIMEOUT_MS

--- a/src/utils/logging/RouteLoggingService.ts
+++ b/src/utils/logging/RouteLoggingService.ts
@@ -1,0 +1,78 @@
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { HttpStatus, Inject, Injectable, Scope } from '@nestjs/common';
+import { WinstonLogLevels } from './enums/WinstonLogLevel';
+import { ILog } from './interfaces/ILog';
+
+/**
+ * Basic route logging service with specific formatted message, using Winston logging library dependency.
+ *
+ * By default, HTTP status code is set to 500 and logging level to `error`.
+ *
+ * A custom message is required to be specified. Make sure it's something meaningful and relevant to the location where the error was thrown.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class RouteLoggingService implements ILog {
+  private loggingLevel: WinstonLogLevels = WinstonLogLevels.error;
+  private httpStatusCode: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+  private customMessage: string;
+  private payload: unknown;
+  private errorStack: string;
+  private errorMessage: string;
+
+  constructor(
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger
+  ) {}
+
+  public log(): Logger {
+    return this.logger.log(this.loggingLevel, this.getFormattedMessage());
+  }
+
+  public setLoggingLevel(loggingLevel: WinstonLogLevels) {
+    this.loggingLevel = loggingLevel;
+    return this;
+  }
+
+  public setHttpStatusCode(httpStatusCode: HttpStatus) {
+    this.httpStatusCode = httpStatusCode;
+    return this;
+  }
+
+  public setCustomMessage(message: string) {
+    this.customMessage = message;
+    return this;
+  }
+
+  public setPayload(payload: unknown) {
+    this.payload = JSON.stringify(payload);
+    return this;
+  }
+
+  public setErrorStack(error: string) {
+    this.errorStack = error;
+    return this;
+  }
+
+  public setErrorMessage(error: string) {
+    this.errorMessage = error;
+    return this;
+  }
+
+  private getFormattedMessage(): string {
+    if (!this.customMessage) {
+      throw new Error('Custom message is required.');
+    }
+    this.customMessage = `
+    [ Log level: ${this.loggingLevel} | HTTP Status Code: ${this.httpStatusCode} ] ${this.customMessage}
+    `;
+    if (this.errorStack || this.errorMessage || this.payload) {
+      this.customMessage += 'Additional information:\n';
+    }
+    if (this.payload) this.customMessage += `[Request body] ${this.payload}\n`;
+    if (this.errorStack)
+      this.customMessage += `[Error stack] ${this.errorStack}\n`;
+    if (this.errorMessage)
+      this.customMessage += `[Error message] ${this.errorMessage}`;
+    return this.customMessage;
+  }
+}

--- a/src/utils/logging/enums/WinstonLogLevel.ts
+++ b/src/utils/logging/enums/WinstonLogLevel.ts
@@ -1,0 +1,9 @@
+export enum WinstonLogLevels {
+  error = 'error',
+  warn = 'warn',
+  info = 'info',
+  http = 'http',
+  verbose = 'verbose',
+  debug = 'debug',
+  silly = 'silly'
+}

--- a/src/utils/logging/interfaces/ILog.ts
+++ b/src/utils/logging/interfaces/ILog.ts
@@ -1,0 +1,3 @@
+export interface ILog {
+  log(fn: FunctionConstructor);
+}

--- a/src/watches/watches.controller.ts
+++ b/src/watches/watches.controller.ts
@@ -1,5 +1,3 @@
-import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { Logger } from 'winston';
 import { Response } from 'express';
 import {
   ParseIntPipe,
@@ -12,7 +10,6 @@ import {
   Delete,
   Res,
   HttpStatus,
-  Inject,
   Query
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -21,14 +18,15 @@ import { WatchesService } from 'src/watches/watches.service';
 import { CreateWatchDto } from 'src/watches/dto/create-watch.dto';
 import { ExistsWatchDto } from 'src/watches/dto/exists-watch.dto';
 import { UpdateWatchDto } from 'src/watches/dto/update-watch.dto';
+
+import { RouteLoggingService } from 'src/utils/logging/RouteLoggingService';
 import { Pagination } from 'src/utils/types/Pagination';
 
 @ApiTags('watches')
 @Controller('watches')
 export class WatchesController {
   constructor(
-    @Inject(WINSTON_MODULE_PROVIDER)
-    private readonly logger: Logger,
+    private readonly routeLoggingService: RouteLoggingService,
     private readonly watchesService: WatchesService
   ) {}
 
@@ -72,15 +70,11 @@ export class WatchesController {
         message: 'A new watch has been added succesfully.'
       });
     } catch (err) {
-      this.logger.log(
-        'error',
-        `${
-          HttpStatus.INTERNAL_SERVER_ERROR
-        } response on create() route handler call with payload: \n ${JSON.stringify(
-          createWatchDto
-        )} \n Err stack: ${err.stack} \n Err message: ${err.message}`,
-        WatchesController.name
-      );
+      this.routeLoggingService.setCustomMessage('create() route handling');
+      this.routeLoggingService.setPayload(createWatchDto);
+      this.routeLoggingService.setErrorStack(err.stack);
+      this.routeLoggingService.setErrorMessage(err.message);
+      this.routeLoggingService.log();
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message:
@@ -140,11 +134,10 @@ export class WatchesController {
         number_of_pages: Math.ceil(totalWatchCount / paginationOptions.limit)
       });
     } catch (err) {
-      this.logger.log(
-        'error',
-        `${HttpStatus.INTERNAL_SERVER_ERROR} response on findAll() route handler call \n Err stack: ${err.stack} | ${err.message} \n`,
-        WatchesController.name
-      );
+      this.routeLoggingService.setCustomMessage('findAll() route handler call');
+      this.routeLoggingService.setErrorStack(err.stack);
+      this.routeLoggingService.setErrorMessage(err.message);
+      this.routeLoggingService.log();
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message:
@@ -194,11 +187,12 @@ export class WatchesController {
         watch
       });
     } catch (err) {
-      this.logger.log(
-        'error',
-        `${HttpStatus.INTERNAL_SERVER_ERROR} response on findOne() route handler call with id ${id} \n Err stack: ${err.stack} \n Err message: ${err.message}`,
-        WatchesController.name
+      this.routeLoggingService.setCustomMessage(
+        `findOne() route handler call with id ${id}`
       );
+      this.routeLoggingService.setErrorStack(err.stack);
+      this.routeLoggingService.setErrorMessage(err.message);
+      this.routeLoggingService.log();
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message:
@@ -265,11 +259,13 @@ export class WatchesController {
         message: 'Watch has been updated succesfully.'
       });
     } catch (err) {
-      this.logger.log(
-        'error',
-        `${HttpStatus.INTERNAL_SERVER_ERROR} response on update() route handler call with id ${id} \n Err stack: ${err.stack} \n Err message: ${err.message}`,
-        WatchesController.name
+      this.routeLoggingService.setCustomMessage(
+        `update() route handler call with id ${id}`
       );
+      this.routeLoggingService.setPayload(updateWatchDto);
+      this.routeLoggingService.setErrorStack(err.stack);
+      this.routeLoggingService.setErrorMessage(err.message);
+      this.routeLoggingService.log();
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message:
@@ -324,11 +320,12 @@ export class WatchesController {
         message: 'Watch has been deleted succesfully.'
       });
     } catch (err) {
-      this.logger.log(
-        'error',
-        `${HttpStatus.INTERNAL_SERVER_ERROR} response on remove() route handler call with id ${id} \n Err stack: ${err.stack} \n Err message: ${err.message}`,
-        WatchesController.name
+      this.routeLoggingService.setCustomMessage(
+        `remove() route handler call with id ${id}`
       );
+      this.routeLoggingService.setErrorStack(err.stack);
+      this.routeLoggingService.setErrorMessage(err.message);
+      this.routeLoggingService.log();
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message:

--- a/src/watches/watches.module.ts
+++ b/src/watches/watches.module.ts
@@ -1,13 +1,36 @@
+import * as winston from 'winston';
+import { WinstonModule } from 'nest-winston';
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { RouteLoggingService } from 'src/utils/logging/RouteLoggingService';
 import { Watch } from './entities/watch.entity';
 import { WatchesController } from './watches.controller';
 import { WatchesService } from './watches.service';
 
 @Module({
   imports: [
+    WinstonModule.forRoot({
+      level: 'error',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.prettyPrint()
+      ),
+      defaultMeta: { service: 'watches-rest-api' },
+      transports: [
+        new winston.transports.File({
+          dirname: 'logs',
+          filename: 'error.log',
+          level: 'error'
+        }),
+        new winston.transports.File({
+          dirname: 'logs',
+          filename: 'combined.log',
+          level: 'http'
+        })
+      ]
+    }),
     ThrottlerModule.forRoot({
       ttl: process.env.THROTTLE_TTL
         ? parseInt(process.env.THROTTLE_TTL as string)
@@ -21,6 +44,7 @@ import { WatchesService } from './watches.service';
   controllers: [WatchesController],
   providers: [
     WatchesService,
+    RouteLoggingService,
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard


### PR DESCRIPTION
Refactoring the old way of logging errors inside WatchesController. It was a functional solution but it was error prone in the long run in the context of having a consistent logging message
I created a new RouteLoggingService which creates a predefined logging message (a template pretty much) out of several properties:
1.  loggingLevel - set by default to 'error'
2. httpStatusCode - set by default to 500
3. customMessage - required | meaningful message related to the location where error was thrown, other useful tips
4. payload - optional | could be passed in POST, PATCH requests to identify whether the issue was due to invalid request body
5. errorStack - optional | although optional, it would be best to include it
6. errorMessage - optional | although optional, it would be best to include it